### PR TITLE
Switch back to SemVer for versioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
           sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' phpunit.test-report.xml
       - name: Extract version number
         run: |
-          echo "PROJECT_VERSION=$(date +%Y.%m)" >> $GITHUB_ENV
+          echo "PROJECT_VERSION=$(sed -n 's/^.*@version \(.*\)$/\1/p' tests/bootstrap.php)" >> $GITHUB_ENV
       - name: SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@master
         with:

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 
     "require": {
         "php": ">=7.4.0",
-        "mundschenk-at/wp-data-storage": "^1.0"
+        "mundschenk-at/wp-data-storage": "^2.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.4",

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,7 +2,7 @@
 /**
  *  This file is part of WordPress Settings UI.
  *
- *  Copyright 2017-2018 Peter Putzer.
+ *  Copyright 2017-2024 Peter Putzer.
  *
  *  This program is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU General Public License
@@ -20,6 +20,8 @@
  *
  *  @package mundschenk-at/wp-settings-ui/tests
  *  @license http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * @version 2.0.0
  */
 
 /**


### PR DESCRIPTION
- Switches back to semantic versioning.
- Updates requirements to `mundschenk-at/wp-data-storage: ^2.0`.